### PR TITLE
Update code to use ENV vars for Jupiter swap api 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,11 @@ This will evolve as we continue to build out the platform and open up more ways 
 ## Getting Help
 
 If you have any additional questions or need help integrating Code into your website or application, please reach out to us on [Discord](https://discord.gg/T8Tpj8DBFp) or [Twitter](https://twitter.com/getcode).
+
+### Using custom Swap API endpoints
+
+You can set custom URLs via the configuration for any self-hosted Jupiter APIs, like the [V6 Swap API](https://station.jup.ag/docs/apis/self-hosted) or [Paid Hosted APIs](https://station.jup.ag/docs/apis/self-hosted#paid-hosted-apis) Here is an example:
+
+```
+JUPITER_API_BASE_URL=https://quote-api.jup.ag/v6/
+```

--- a/pkg/jupiter/client.go
+++ b/pkg/jupiter/client.go
@@ -22,7 +22,7 @@ import (
 // Reference: https://station.jup.ag/docs/apis/swap-api + https://www.jupiterapi.com
 
 var (
-	DefaultApiBaseUrl = getEnv("JUPITER_API_BASE_URL", "https://quote-api.jup.ag/v6/")
+	DefaultApiBaseUrl = getEnv("JUPITER_API_BASE_URL", "https://public.jupiterapi.com/")
 
 	quoteEndpointName            = "quote"
 	swapInstructionsEndpointName = "swap-instructions"

--- a/pkg/jupiter/client.go
+++ b/pkg/jupiter/client.go
@@ -22,7 +22,7 @@ import (
 // Reference: https://station.jup.ag/docs/apis/swap-api + https://www.jupiterapi.com
 
 var (
-	DefaultApiBaseUrl = getEnv("JUPITER_API_BASE_URL", "https://public.jupiterapi.com/")
+	DefaultApiBaseUrl = getEnv("JUPITER_API_BASE_URL", "https://quote-api.jup.ag/v6/")
 
 	quoteEndpointName            = "quote"
 	swapInstructionsEndpointName = "swap-instructions"

--- a/pkg/jupiter/client.go
+++ b/pkg/jupiter/client.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+
 	"net/http"
 	"strconv"
 	"strings"
@@ -17,16 +19,25 @@ import (
 	"github.com/code-payments/code-server/pkg/solana"
 )
 
-// Reference: https://station.jup.ag/docs/apis/swap-api
+// Reference: https://station.jup.ag/docs/apis/swap-api + https://www.jupiterapi.com
 
-const (
-	DefaultApiBaseUrl = "https://quote-api.jup.ag/v6/"
+var (
+	DefaultApiBaseUrl = getEnv("JUPITER_API_BASE_URL", "https://public.jupiterapi.com/")
 
 	quoteEndpointName            = "quote"
 	swapInstructionsEndpointName = "swap-instructions"
 
 	metricsStructName = "jupiter.client"
 )
+
+// getEnv tries to get the value of an environment variable named key
+// and returns the value if found, or fallback value if not found.
+func getEnv(key, fallback string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return fallback
+}
 
 type Client struct {
 	baseUrl    string


### PR DESCRIPTION
Allows for the Jupiter V6 Swap API url to be configured via an environment variable while defaulting to the original hardcoded value and document the use of it. This should be helpful for cases where customers run into rate limits with the public API or are looking for lower latency with self/paid hosted installations.

Changes:
- Makes the Jupiter Swap V6 API base URL configurable.
- Changes default URL to public.jupiterapi.com with higher rate limits. (see [jupiterapi.com](jupiterapi.com))
- Updates the README.