### PR TITLE
etcd: add PersistentLease and WatchPrefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ build/
 # Visual Studio Code
 .vscode/
 
+# Jetbrains
+.idea/
+

--- a/go.mod
+++ b/go.mod
@@ -35,8 +35,10 @@ require (
 	github.com/twilio/twilio-go v0.26.0
 	github.com/vence722/base122-go v0.0.2
 	github.com/ybbus/jsonrpc v2.1.2+incompatible
+	go.etcd.io/etcd/api/v3 v3.5.13
 	go.etcd.io/etcd/client/v3 v3.5.13
 	golang.org/x/crypto v0.21.0
+	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842
 	golang.org/x/net v0.22.0
 	golang.org/x/text v0.14.0
 	golang.org/x/time v0.5.0
@@ -106,7 +108,6 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
-	go.etcd.io/etcd/api/v3 v3.5.13 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.5.13 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
@@ -118,7 +119,7 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect
-	golang.org/x/sync v0.6.0 // indirect
+	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/appengine/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -640,6 +640,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200331195152-e8c3332aa8e5/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
+golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -746,8 +748,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
-golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=
+golang.org/x/sync v0.7.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/etcd/persistent_lease.go
+++ b/pkg/etcd/persistent_lease.go
@@ -1,0 +1,187 @@
+package etcd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	v3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+
+	"github.com/code-payments/code-server/pkg/retry"
+	"github.com/code-payments/code-server/pkg/retry/backoff"
+)
+
+// PersistentLease is "persistent" lease in etcd.
+//
+// While name sounds contradictory, it's behaviour is that while the
+// PersistentLease is not closed, it will continually try to keep the
+// <key, value> pair present in etcd, _attached_ to a lease. This
+// process will only end when Close() is called.
+//
+// PersistentLease's are useful in situations where we want to register
+// the presence of a server/node in a cluster. The use of a lease ensures
+// that if the process crashes or becomes partitioned from etcd, the
+// value gets automatically removed. The 'persistent' component ensures that
+// when the network partition is restored (or whatever failure mode that caused
+// the lease to expire recovers), the <key, value> pair will be placed back
+// automatically.
+type PersistentLease struct {
+	log    *logrus.Entry
+	client *v3.Client
+	ttl    int
+
+	key        string
+	val        string
+	valCh      chan string
+	recreateCh chan struct{}
+
+	closeFn sync.Once
+	closeCh chan struct{}
+}
+
+// NewPersistentLease creates a new PersistentLease which starts immediately
+// in the background.
+func NewPersistentLease(client *v3.Client, key, val string, ttl time.Duration) (*PersistentLease, error) {
+	ttlSeconds := ttl.Truncate(time.Second).Seconds()
+	if ttlSeconds < 1 || ttlSeconds > 60 { // Bounded by etcd library.
+		return nil, fmt.Errorf("invalid ttl %v: must be [1, 60]", ttl)
+	}
+
+	pl := &PersistentLease{
+		log: logrus.StandardLogger().WithFields(logrus.Fields{
+			"type": "etcd/persistent_lease",
+			"key":  key,
+		}),
+		client: client,
+		ttl:    int(ttlSeconds),
+
+		key:        key,
+		val:        val,
+		valCh:      make(chan string),
+		recreateCh: make(chan struct{}),
+
+		closeCh: make(chan struct{}),
+	}
+
+	go pl.syncLoop()
+	go pl.watchExistence()
+
+	return pl, nil
+}
+
+// SetValue sets the new value for the persistent lease.
+//
+// SetValue is done concurrently, so there are no guarantees for when this will propagate.
+// To wait for the value to be replicated, a Get()/Watch() should be used.
+func (pl *PersistentLease) SetValue(val string) {
+	pl.valCh <- val
+}
+
+// Close closes the PersistentLease, terminating all background jobs.
+//
+// Close is idempotent. A PersistentLease cannot be restarted, however.
+func (pl *PersistentLease) Close() {
+	pl.closeFn.Do(func() {
+		close(pl.closeCh)
+	})
+}
+
+// syncLoop ensures that we always have an active session, and that our
+// value is up-to-date.
+//
+// The loop re-runs on session loss, SetValue() emitting a value, or if
+// watchExistence() detects a loss.
+func (pl *PersistentLease) syncLoop() {
+	_, _ = retry.Retry(
+		func() error {
+			session, err := concurrency.NewSession(pl.client, concurrency.WithTTL(pl.ttl))
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := session.Close(); err != nil {
+					pl.log.WithError(err).Warn("Failed to close session")
+				}
+			}()
+
+			for {
+				ctx, cancel := context.WithTimeout(context.Background(), (time.Duration(pl.ttl) * time.Second).Truncate(time.Second))
+				_, err := pl.client.Put(ctx, pl.key, pl.val, v3.WithLease(session.Lease()))
+				cancel()
+				if err != nil {
+					return fmt.Errorf("failed to write key %q: %w", pl.key, err)
+				}
+
+				select {
+				case <-pl.closeCh:
+					return nil
+				case <-session.Done():
+					return errors.New("session closed")
+				case <-pl.recreateCh:
+					// Our watcher has indicated that we aren't visible!
+				case pl.val = <-pl.valCh:
+					// Value has changed, update it
+				}
+			}
+		},
+		func(attempts uint, err error) bool {
+			pl.log.WithError(err).Warn("failure in lease loop")
+			return true
+		},
+		retry.BackoffWithJitter(backoff.Constant(time.Second), time.Second, 0.1),
+	)
+}
+
+// watchExistence watches the specified key to ensure it exists.
+//
+// This provides resilience against external actors removing the key.
+// Additionally, it helps provide some extra checks if the syncLoop()
+// doesn't detect a session loss.
+func (pl *PersistentLease) watchExistence() {
+	_, _ = retry.Retry(
+		func() error {
+			select {
+			case <-pl.closeCh:
+				return nil
+			default:
+			}
+
+			cancelledCh := make(chan struct{})
+			defer close(cancelledCh)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				select {
+				case <-pl.closeCh:
+				case <-cancelledCh:
+				}
+
+				cancel()
+			}()
+
+			watchCh := pl.client.Watch(ctx, pl.key)
+			for w := range watchCh {
+				if w.Err() != nil {
+					return w.Err()
+				}
+
+				for _, e := range w.Events {
+					if e.Type == v3.EventTypeDelete {
+						pl.recreateCh <- struct{}{}
+					}
+				}
+			}
+
+			return nil
+		},
+		func(attempts uint, err error) bool {
+			pl.log.WithError(err).Warn("failure in lease loop")
+			return true
+		},
+		retry.BackoffWithJitter(backoff.Constant(time.Second), time.Second, 0.1),
+	)
+}

--- a/pkg/etcd/persistent_lease_test.go
+++ b/pkg/etcd/persistent_lease_test.go
@@ -1,0 +1,75 @@
+package etcd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+	v3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/code-payments/code-server/pkg/etcdtest"
+)
+
+func TestPersistentLease(t *testing.T) {
+	require := require.New(t)
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(err)
+
+	client, teardown, err := etcdtest.StartEtcd(pool)
+	require.NoError(err)
+	defer teardown()
+
+	key := "/cluster/me"
+	value := "initial"
+
+	pl, err := NewPersistentLease(client, key, value, 10*time.Second)
+	require.NoError(err)
+
+	// Ensure the KV is recreated on:
+	//   1. External removal of KV.
+	//   2. The lease is revoked.
+	for i := 0; i < 5; i++ {
+		require.Eventually(func() bool {
+			resp, err := client.Get(context.Background(), key)
+			require.NoError(err)
+			return len(resp.Kvs) == 1
+		}, 3*time.Second, 100*time.Millisecond)
+
+		resp, err := client.Get(context.Background(), key)
+		require.NoError(err)
+		require.Len(resp.Kvs, 1)
+		require.Equal(key, string(resp.Kvs[0].Key))
+		require.Equal(value, string(resp.Kvs[0].Value))
+		require.NotZero(resp.Kvs[0].Lease)
+
+		if i%2 == 0 {
+			_, err = client.Delete(context.Background(), key)
+			require.NoError(err)
+		} else {
+			_, err = client.Revoke(context.Background(), v3.LeaseID(resp.Kvs[0].Lease))
+			require.NoError(err)
+		}
+	}
+
+	pl.SetValue("modified")
+	require.Eventually(func() bool {
+		resp, err := client.Get(context.Background(), key)
+		if err != nil {
+			return false
+		}
+		return len(resp.Kvs) == 1 && string(resp.Kvs[0].Value) == "modified"
+	}, 3*time.Second, 100*time.Millisecond)
+
+	pl.Close()
+
+	require.Eventually(func() bool {
+		resp, err := client.Get(context.Background(), key)
+		if err != nil {
+			return false
+		}
+		return len(resp.Kvs) == 0
+	}, 3*time.Second, 100*time.Millisecond)
+}

--- a/pkg/etcd/watch.go
+++ b/pkg/etcd/watch.go
@@ -1,0 +1,136 @@
+package etcd
+
+import (
+	"context"
+	"github.com/code-payments/code-server/pkg/retry/backoff"
+	"maps"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	v3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/code-payments/code-server/pkg/retry"
+)
+
+// Snapshot contains a "tree" at a given point in time.
+//
+// The tree is all <Key, Value> pairs matching a prefix.
+type Snapshot[K comparable, V any] struct {
+	Tree map[K]V
+}
+
+// KVTransform transforms a <Key, Value> pair from etcd into a
+// <K, V> mapping suitable to the use-case of Snapshot[K, V].
+//
+// Example: K is the ID of an item, where V is the information about it.
+type KVTransform[K comparable, V any] func(k, v []byte) (K, V, error)
+
+// WatchPrefix watches a prefix _forever_ until the provided context
+// is cancelled.
+//
+// The returned channel emits Snapshot's of the tree.
+// The returned channel closes when the provided ctx is cancelled.
+func WatchPrefix[K comparable, V any](
+	ctx context.Context,
+	client *v3.Client,
+	prefix string,
+	transform KVTransform[K, V],
+) <-chan Snapshot[K, V] {
+	log := logrus.StandardLogger().WithFields(logrus.Fields{
+		"method": "WatchPrefix",
+		"prefix": prefix,
+	})
+
+	ch := make(chan Snapshot[K, V], 1)
+
+	loop := func() error {
+		get, err := client.Get(ctx, prefix, v3.WithPrefix())
+		if err != nil {
+			return err
+		}
+
+		if get.More {
+			log.WithFields(logrus.Fields{
+				"total":    get.Count,
+				"returned": len(get.Kvs),
+			})
+		}
+
+		tree := make(map[K]V)
+		for i := range get.Kvs {
+			key, val, err := transform(get.Kvs[i].Key, get.Kvs[i].Value)
+			if err != nil {
+				log.WithError(err).
+					WithField("key", string(get.Kvs[i].Key)).
+					Warn("Invalid record, dropping")
+
+				continue
+			}
+
+			tree[key] = val
+		}
+
+		ch <- Snapshot[K, V]{Tree: maps.Clone(tree)}
+
+		watchCh := client.Watch(
+			ctx,
+			prefix,
+			v3.WithPrefix(),
+			v3.WithRev(get.Header.Revision+1),
+			v3.WithPrevKV(), // Note: Important for delete case.
+		)
+
+		for watch := range watchCh {
+			if err := watch.Err(); err != nil {
+				return err
+			}
+
+			for _, event := range watch.Events {
+				switch event.Type {
+				case v3.EventTypePut:
+					key, val, err := transform(event.Kv.Key, event.Kv.Value)
+					if err != nil {
+						log.WithError(err).
+							WithField("key", string(event.Kv.Key)).
+							Warn("Invalid record, dropping")
+
+						continue
+					}
+
+					tree[key] = val
+				case v3.EventTypeDelete:
+					key, _, err := transform(event.PrevKv.Key, event.PrevKv.Value)
+					if err != nil {
+						log.WithError(err).
+							WithField("key", string(event.Kv.Key)).
+							Warn("Invalid record, dropping (drop)")
+
+						continue
+					}
+
+					delete(tree, key)
+				}
+			}
+
+			ch <- Snapshot[K, V]{Tree: maps.Clone(tree)}
+		}
+
+		return nil
+	}
+
+	go func() {
+		_, _ = retry.Retry(
+			loop,
+			func(attempts uint, err error) bool {
+				log.WithError(err).Warn("Failure during watch loop")
+				return true
+			},
+			retry.NonRetriableErrors(context.Canceled),
+			retry.BackoffWithJitter(backoff.Constant(time.Second), 2*time.Second, 0.1),
+		)
+		log.Info("Closed")
+		close(ch)
+	}()
+
+	return ch
+}

--- a/pkg/etcd/watch_test.go
+++ b/pkg/etcd/watch_test.go
@@ -1,0 +1,100 @@
+package etcd
+
+import (
+	"bytes"
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
+
+	"github.com/code-payments/code-server/pkg/etcdtest"
+)
+
+func TestWatch(t *testing.T) {
+	require := require.New(t)
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(err)
+
+	client, teardown, err := etcdtest.StartEtcd(pool)
+	require.NoError(err)
+	defer teardown()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, err = client.Put(ctx, "/my/tree/one", "1")
+	require.NoError(err)
+	_, err = client.Put(ctx, "/my/tree/two", "2")
+	require.NoError(err)
+
+	var statesMu sync.Mutex
+	var snapshots []Snapshot[string, int64]
+
+	ch := WatchPrefix(
+		ctx,
+		client,
+		"/my/tree",
+		func(k, v []byte) (string, int64, error) {
+			keyParts := bytes.Split(k, []byte("/"))
+			key := string(keyParts[len(keyParts)-1])
+			val, err := strconv.ParseInt(string(v), 10, 64)
+			if err != nil {
+				return key, 0, err
+			}
+			return key, val, nil
+		},
+	)
+	go func() {
+		for snapshot := range ch {
+			statesMu.Lock()
+			snapshots = append(snapshots, snapshot)
+			statesMu.Unlock()
+		}
+	}()
+
+	require.Eventually(func() bool {
+		statesMu.Lock()
+		defer statesMu.Unlock()
+		return len(snapshots) > 0
+	}, 2*time.Second, 50*time.Millisecond)
+
+	_, err = client.Delete(ctx, "/my/tree/two")
+	require.NoError(err)
+	_, err = client.Put(ctx, "/my/tree/one", "10")
+	require.NoError(err)
+	_, err = client.Put(ctx, "/my/tree/three", "3")
+	require.NoError(err)
+
+	require.Eventually(func() bool {
+		statesMu.Lock()
+		defer statesMu.Unlock()
+		return len(snapshots) > 0
+	}, 2*time.Second, 50*time.Millisecond)
+
+	expected := []map[string]int64{
+		{
+			"one": 1,
+			"two": 2,
+		},
+		{
+			"one": 1,
+		},
+		{
+			"one": 10,
+		},
+		{
+			"one":   10,
+			"three": 3,
+		},
+	}
+
+	for i := range expected {
+		require.True(maps.Equal(expected[i], snapshots[i].Tree))
+	}
+}


### PR DESCRIPTION
PersistentLease is a foundational component for service registries and cluster memeberships. This will be useful in the future for coordination, such as messaging and/or distributed NoncePools.

WatchPrefix is the read aspect of this, where we watch a set of KVs under a prefix (in a snapshotting fashion) to be able to read members of a cluster.