### PR TITLE
cluster/grpc: add clustered gRPC client and example

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -75,13 +75,15 @@ type Membership interface {
 
 	// Register registers the membership with the cluster.
 	//
-	// There is no guarantee for when the member will
-	// propagate to the rest of the members.
+	// Register will block until the local process observes the
+	// registration, but there is no guarantee for when other members
+	// will observe the change.
 	Register(ctx context.Context) error
 
-	// Deregister deregisters the membership with the cluster.
+	// Deregister de-registers the membership with the cluster.
 	//
-	// There is no guarantee for when the deregistration will
-	// propagate to the rest of the members.
+	// Deregister will block until the local process observes the
+	// de-registration, but there is no guarantee for when other members
+	// will observer the change.
 	Deregister(ctx context.Context) error
 }

--- a/pkg/cluster/grpc/balancer.go
+++ b/pkg/cluster/grpc/balancer.go
@@ -1,0 +1,200 @@
+package grpc
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/resolver"
+
+	"github.com/code-payments/code-server/pkg/cluster/registry"
+	"github.com/code-payments/code-server/pkg/cluster/ring"
+)
+
+const (
+	BalancerName   = "cluster"
+	BalancerConfig = `{"loadBalancingConfig": [{"cluster": {}}]}`
+)
+
+func RegisterLoadBalancer(registry registry.Reader) {
+	balancer.Register(&balancerBuilder{
+		log:    logrus.WithField("type", "cluster/grpc/balancer"),
+		reader: registry,
+	})
+}
+
+type balancerBuilder struct {
+	log    *logrus.Entry
+	reader registry.Reader
+}
+
+func (b *balancerBuilder) Name() string {
+	return BalancerName
+}
+
+func (b *balancerBuilder) Build(cc balancer.ClientConn, _ balancer.BuildOptions) balancer.Balancer {
+	return &sbBalancer{
+		log:    b.log,
+		reader: b.reader,
+		cc:     cc,
+
+		subConns: make(map[string]balancer.SubConn),
+		scStates: make(map[balancer.SubConn]balancer.SubConnState),
+		scNodes:  make(map[balancer.SubConn]*registry.NodeDescriptor),
+	}
+}
+
+type sbBalancer struct {
+	log    *logrus.Entry
+	reader registry.Reader
+	cc     balancer.ClientConn
+
+	picker balancer.Picker
+
+	mu       sync.RWMutex
+	subConns map[string]balancer.SubConn
+	scStates map[balancer.SubConn]balancer.SubConnState
+	scNodes  map[balancer.SubConn]*registry.NodeDescriptor
+}
+
+func (b *sbBalancer) UpdateClientConnState(state balancer.ClientConnState) error {
+	tokenRing := state.ResolverState.Attributes.Value(ringAttributeKey).(*ring.HashRing)
+	if tokenRing == nil {
+		return fmt.Errorf("missing ring: balancer must be used with resolver")
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	addressSet := make(map[string]struct{})
+
+	for _, addr := range state.ResolverState.Addresses {
+		node, ok := addr.Attributes.Value(contextKeyNode).(*registry.NodeDescriptor)
+		if !ok {
+			b.log.Warn("NodeDescriptor not present in metadata, ignoring", zap.String("address", addr.Addr))
+			continue
+		}
+
+		addressSet[addr.Addr] = struct{}{}
+
+		// If we already have a SubConn for the address, then we're simply updating
+		// the NodeDescriptor state. The picker will deal with any routing level updates.
+		if sc, ok := b.subConns[addr.Addr]; ok {
+			b.scNodes[sc] = node
+			continue
+		}
+
+		// Set up a new SubConn for the newly observed Node.
+		sc, err := b.cc.NewSubConn([]resolver.Address{addr}, balancer.NewSubConnOptions{})
+		if err != nil {
+			b.log.Warn("Failed to create new SubConn", zap.Error(err), zap.String("address", addr.Addr))
+			continue
+		}
+
+		b.log.Debug("Created new SubConn", zap.String("address", addr.Addr))
+
+		b.subConns[addr.Addr] = sc
+		b.scStates[sc] = balancer.SubConnState{ConnectivityState: connectivity.Idle}
+		b.scNodes[sc] = node
+
+		// We want to immediately start the connection flow to help reduce 'cold starts' on actual requests.
+		//
+		// Note: In a multi-service world, we would only want to do this on services that we've actually communicated
+		// with in the past to reduce the number of overall connections. However, cluster sizes should be relatively
+		// small and homogeneous.
+		sc.Connect()
+	}
+
+	// Prune any SubConn's for nodes that are no longer resolved.
+	for addr, sc := range b.subConns {
+		if _, ok := addressSet[addr]; !ok {
+			// Note: The reason we're deleting from subConns and _not_ scStates/scNodes is
+			// that they're required to correctly transition the state into Shutdown.
+			//
+			// See UpdateSubConnState() below for their transition.
+			delete(b.subConns, addr)
+
+			sc.Shutdown()
+		}
+	}
+
+	b.regeneratePicker(tokenRing)
+
+	// We just report the Balancer as ready (which in turn indicates that the ClientConn is ready)
+	// as we don't do any connection warming or probing.
+	//
+	// In theory, this should only affect Dial() when `WithBlock()` is used. This behaviour
+	// effectively makes the `WithBlock()` a no-op.
+	b.cc.UpdateState(balancer.State{Picker: b.picker, ConnectivityState: connectivity.Ready})
+	return nil
+}
+
+func (b *sbBalancer) UpdateSubConnState(sc balancer.SubConn, newState balancer.SubConnState) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	oldState, ok := b.scStates[sc]
+	if !ok {
+		b.log.
+			WithField("new_state", newState.ConnectivityState.String()).
+			Warn("State change for unknown SubConn")
+
+		return
+	}
+	b.scStates[sc] = newState
+
+	node, ok := b.scNodes[sc]
+	if !ok {
+		b.log.Warn("NodeDescriptor doesn't exist for SubConn")
+		return
+	}
+
+	address := fmt.Sprintf("%s:%d", node.Address.IP, node.Address.Port)
+	switch newState.ConnectivityState {
+	case connectivity.Idle:
+		b.log.WithField("address", address).Debug("SubConn changed to idle; reconnecting")
+		sc.Connect()
+	case connectivity.Shutdown:
+		b.log.
+			WithField("address", address).
+			WithError(newState.ConnectionError).
+			Debug("SubConn shutting down")
+
+		delete(b.scStates, sc)
+		delete(b.scNodes, sc)
+	}
+
+	// There's a slightly sinister case where the Picker may block if the selected
+	// SubConn is non-ready. In this case, it will wait until UpdateState() is called
+	// again (by us, the LoadBalancer).
+	//
+	// To help avoid/unblock this case, we poke the picker (via UpdateState) every time
+	// we see a state transition.
+	//
+	// This behavior is acceptable in small homogeneous clusters, but maybe revised in
+	// larger deploys (by service).
+	if (oldState.ConnectivityState == connectivity.Ready) != (newState.ConnectivityState == connectivity.Ready) {
+		b.cc.UpdateState(balancer.State{Picker: b.picker, ConnectivityState: connectivity.Ready})
+	}
+}
+
+func (b *sbBalancer) ResolverError(err error) {
+	b.log.WithError(err).Error("Unexpected resolver error")
+}
+
+func (b *sbBalancer) Close() {
+}
+
+func (b *sbBalancer) regeneratePicker(tokenRing *ring.HashRing) {
+	b.log.WithField("nodes", len(b.scNodes)).Debug("Regenerating picker")
+
+	nodes := make([]*registry.NodeDescriptor, 0, len(b.scNodes))
+	for _, node := range b.scNodes {
+		nodes = append(nodes, node)
+	}
+
+	b.picker = newPicker(nodes, b.scNodes, tokenRing)
+}

--- a/pkg/cluster/grpc/context.go
+++ b/pkg/cluster/grpc/context.go
@@ -1,0 +1,21 @@
+package grpc
+
+import (
+	"context"
+)
+
+type contextKey int
+
+const (
+	contextKeyRouting contextKey = iota
+	contextKeyNode
+)
+
+func WithRoutingKey(parent context.Context, val []byte) context.Context {
+	return context.WithValue(parent, contextKeyRouting, val)
+}
+
+func RoutingKey(ctx context.Context) (val []byte, ok bool) {
+	val, ok = ctx.Value(contextKeyRouting).([]byte)
+	return
+}

--- a/pkg/cluster/grpc/example/cluster.go
+++ b/pkg/cluster/grpc/example/cluster.go
@@ -1,0 +1,187 @@
+package example
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc"
+
+	commonpb "github.com/code-payments/code-protobuf-api/generated/go/common/v1"
+	invitepb "github.com/code-payments/code-protobuf-api/generated/go/invite/v2"
+
+	cgrpc "github.com/code-payments/code-server/pkg/cluster/grpc"
+	"github.com/code-payments/code-server/pkg/cluster/registry"
+)
+
+type ClusteredInviteService struct {
+	nodeID                   string
+	serverID                 int
+	registry                 registry.Observer
+	forwardingClientProvider func() invitepb.InviteClient
+
+	closeFn sync.Once
+	closeCh chan struct{}
+
+	cacheMu sync.Mutex
+	cache   map[string]struct{}
+
+	invitepb.UnimplementedInviteServer
+}
+
+func NewClusteredInviteService(
+	nodeID string,
+	serverID int,
+	registry registry.Observer,
+	forwardingClientProvider func() invitepb.InviteClient,
+) *ClusteredInviteService {
+	s := &ClusteredInviteService{
+		nodeID:                   nodeID,
+		serverID:                 serverID,
+		registry:                 registry,
+		forwardingClientProvider: forwardingClientProvider,
+
+		closeCh: make(chan struct{}),
+
+		cache: make(map[string]struct{}),
+	}
+
+	go s.cacheLoop()
+
+	return s
+}
+
+func (c *ClusteredInviteService) GetInviteCount(ctx context.Context, req *invitepb.GetInviteCountRequest) (*invitepb.GetInviteCountResponse, error) {
+	mismatch := c.registry.Owner(req.UserId.Value) != c.nodeID
+	if mismatch {
+		if fc := c.forwardingClientProvider(); fc != nil {
+			resp, err := fc.GetInviteCount(cgrpc.WithRoutingKey(ctx, req.UserId.Value), req)
+			if err != nil {
+				return nil, err
+			}
+
+			return &invitepb.GetInviteCountResponse{
+				InviteCount: resp.InviteCount,
+			}, nil
+		}
+	}
+
+	cacheKey := string(req.UserId.Value)
+	c.cacheMu.Lock()
+	_, cached := c.cache[cacheKey]
+	c.cache[cacheKey] = struct{}{}
+	c.cacheMu.Unlock()
+
+	result := NewResult(req.UserId, c.serverID, mismatch, cached)
+	return &invitepb.GetInviteCountResponse{
+		InviteCount: uint32(result),
+	}, nil
+}
+
+func (c *ClusteredInviteService) Close() {
+	c.closeFn.Do(func() {
+		close(c.closeCh)
+	})
+}
+
+// cacheLoop is an example of keeping the local state eventually consistent
+// with the cluster state. This use case is particularly notable if we have
+// caching (though beware of inconsistency) or user sessions (where we would
+// want to force them to reconnect on change).
+func (c *ClusteredInviteService) cacheLoop() {
+	// The loop _may_ be expensive, so we take care to not block the WatchNodes()
+	// call. A buffer of 1 _should_ suffice since we don't care about the actual set change.
+	//
+	// If we want to be _extra_ paranoid, we can use a ticker for eventual consistency.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		<-c.closeCh
+		cancel()
+	}()
+
+	changeCh := make(chan struct{}, 1)
+	go func() {
+		membershipChangeCh := c.registry.WatchNodes(ctx)
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-membershipChangeCh:
+			case <-ticker.C:
+			}
+
+			select {
+			case changeCh <- struct{}{}:
+			default:
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-c.closeCh:
+			return
+		case <-changeCh:
+		}
+
+		c.cacheMu.Lock()
+		for k := range c.cache {
+			if c.registry.Owner([]byte(k)) != c.nodeID {
+				delete(c.cache, k)
+			}
+		}
+		c.cacheMu.Unlock()
+	}
+}
+
+type ClusteredInviteClient struct {
+	client invitepb.InviteClient
+}
+
+func NewClusteredInviteClient(cc grpc.ClientConnInterface) *ClusteredInviteClient {
+	return &ClusteredInviteClient{client: invitepb.NewInviteClient(cc)}
+}
+
+func (c *ClusteredInviteClient) GetInviteCount(ctx context.Context, in *invitepb.GetInviteCountRequest, opts ...grpc.CallOption) (*invitepb.GetInviteCountResponse, error) {
+	return c.client.GetInviteCount(cgrpc.WithRoutingKey(ctx, in.GetUserId().Value), in, opts...)
+}
+
+func (c *ClusteredInviteClient) InvitePhoneNumber(ctx context.Context, in *invitepb.InvitePhoneNumberRequest, opts ...grpc.CallOption) (*invitepb.InvitePhoneNumberResponse, error) {
+	panic("implement me")
+}
+
+func (c *ClusteredInviteClient) GetInvitationStatus(ctx context.Context, in *invitepb.GetInvitationStatusRequest, opts ...grpc.CallOption) (*invitepb.GetInvitationStatusResponse, error) {
+	panic("implement me")
+}
+
+type Result uint32
+
+func NewResult(userID *commonpb.UserId, serverID int, mismatch, cached bool) Result {
+	var m uint32
+	if mismatch {
+		m = 1
+	}
+	if cached {
+		m |= 2
+	}
+
+	return Result(uint32(userID.Value[0]) | uint32((serverID&0xff)<<8) | m<<16)
+}
+
+func (r Result) GetUserID() []byte {
+	return []byte{byte(r & 0xff)}
+}
+
+func (r Result) GetServerIndex() int {
+	return int((r >> 8) & 0xff)
+}
+
+func (r Result) Mismatch() bool {
+	return (r>>16)&0x01 == 1
+}
+
+func (r Result) Cached() bool {
+	return (r>>16)&0x02 == 2
+}

--- a/pkg/cluster/grpc/example/cluster_test.go
+++ b/pkg/cluster/grpc/example/cluster_test.go
@@ -1,0 +1,280 @@
+package example
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/nettest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	commonpb "github.com/code-payments/code-protobuf-api/generated/go/common/v1"
+	invitepb "github.com/code-payments/code-protobuf-api/generated/go/invite/v2"
+
+	cgrpc "github.com/code-payments/code-server/pkg/cluster/grpc"
+	"github.com/code-payments/code-server/pkg/cluster/memory"
+	"github.com/code-payments/code-server/pkg/cluster/registry"
+)
+
+type testServer struct {
+	lis     net.Listener
+	serv    *grpc.Server
+	node    registry.Node
+	service *ClusteredInviteService
+}
+
+func (t *testServer) close() {
+	if node := t.node; node != nil {
+		_ = node.Deregister(context.Background())
+	}
+	if serv := t.serv; serv != nil {
+		serv.GracefulStop()
+	}
+	if l := t.lis; l != nil {
+		_ = l.Close()
+	}
+	if service := t.service; service != nil {
+		service.Close()
+	}
+}
+
+func setupServers(
+	require *require.Assertions,
+	r *registry.ClusteredRegistry,
+	n int,
+	clientProvider func() invitepb.InviteClient,
+) ([]*testServer, func()) {
+	servers := make([]*testServer, n)
+	cleanup := func() {
+		for _, server := range servers {
+			server.close()
+		}
+	}
+
+	for i := range servers {
+		lis, err := nettest.NewLocalListener("tcp")
+		require.NoError(err)
+
+		node, err := r.NewNode(lis.Addr().String())
+		require.NoError(err)
+		require.NoError(node.SetWeight(500))
+
+		require.NoError(node.Register(context.Background()))
+
+		servers[i] = &testServer{
+			lis:  lis,
+			serv: grpc.NewServer(),
+			node: node,
+			service: NewClusteredInviteService(
+				node.ID(),
+				i,
+				r,
+				clientProvider,
+			),
+		}
+
+		invitepb.RegisterInviteServer(servers[i].serv, servers[i].service)
+
+		go func(i int) {
+			_ = servers[i].serv.Serve(lis)
+		}(i)
+	}
+
+	require.Eventually(func() bool {
+		nodes, _ := r.GetNodes()
+		return len(nodes) == n
+	}, 5*time.Second, 10*time.Millisecond)
+
+	return servers, cleanup
+}
+
+func TestNoForwardRouting(t *testing.T) {
+	require := require.New(t)
+
+	cluster := memory.NewCluster()
+	registry := registry.NewClusteredRegistry(cluster)
+
+	// Deployments using the gRPC cluster should install these globally.
+	cgrpc.RegisterResolver(registry)
+	cgrpc.RegisterLoadBalancer(registry)
+	servers, cleanup := setupServers(require, registry, 5, func() invitepb.InviteClient {
+		return nil
+	})
+	defer cleanup()
+
+	go func() {
+		log.Println(http.ListenAndServe("localhost:6060", nil))
+	}()
+
+	cc, err := grpc.Dial(
+		"cluster://authority/endpoint",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(cgrpc.BalancerConfig),
+	)
+	require.NoError(err)
+
+	inviteClient := invitepb.NewInviteClient(cc)
+
+	for u := 0; u < 20; u++ {
+		userID := &commonpb.UserId{Value: []byte{byte(u)}}
+
+		//
+		// Test 1: No routing key is provided, and so falls back to round-robin
+		//
+		requests := 1000
+		serverHits := map[int]int{}
+		if true {
+			for i := 0; i < requests; i++ {
+				resp, err := inviteClient.GetInviteCount(context.Background(), &invitepb.GetInviteCountRequest{
+					UserId: userID,
+				})
+				require.NoError(err)
+
+				result := Result(resp.InviteCount)
+				serverHits[result.GetServerIndex()]++
+			}
+
+			require.Greater(len(serverHits), 2)
+			for _, hits := range serverHits {
+				require.InDelta(
+					1/float64(len(servers)),
+					float64(hits)/float64(requests),
+					0.05,
+				)
+			}
+		}
+
+		//
+		// Test 2: Routing key is provided, so we expect it to hit the same server every time.
+		//
+		clear(serverHits)
+		ctx := cgrpc.WithRoutingKey(context.Background(), userID.Value)
+		mismatches := 0
+		for i := 0; i < 10; i++ {
+			resp, err := inviteClient.GetInviteCount(ctx, &invitepb.GetInviteCountRequest{
+				UserId: userID,
+			})
+			require.NoError(err)
+
+			result := Result(resp.InviteCount)
+			require.False(result.Mismatch())
+			if i > 0 {
+				require.True(result.Cached())
+			}
+			serverHits[result.GetServerIndex()]++
+		}
+
+		require.Len(serverHits, 1)
+		require.Zero(mismatches)
+	}
+
+	fmt.Println("done")
+}
+
+func TestForwardRouting(t *testing.T) {
+	require := require.New(t)
+
+	cluster := memory.NewCluster()
+	registry := registry.NewClusteredRegistry(cluster)
+
+	// Deployments using the gRPC cluster should install these globally.
+	cgrpc.RegisterResolver(registry)
+	cgrpc.RegisterLoadBalancer(registry)
+
+	var forwardingClient invitepb.InviteClient
+	clientProvider := func() invitepb.InviteClient {
+		return forwardingClient
+	}
+
+	servers, cleanup := setupServers(require, registry, 2, clientProvider)
+	defer cleanup()
+
+	cc, err := grpc.Dial(
+		"cluster://authority/endpoint",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(cgrpc.BalancerConfig),
+	)
+	require.NoError(err)
+
+	forwardingClient = invitepb.NewInviteClient(cc)
+
+	userID := &commonpb.UserId{Value: []byte{20}}
+	owner := registry.Owner(userID.Value)
+	ownerIndex := 0
+	for _, s := range servers {
+		if s.service.nodeID == owner {
+			ownerIndex = s.service.serverID
+		} else {
+			cc, err = grpc.Dial(
+				s.lis.Addr().String(),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+		}
+	}
+
+	require.NotNil(cc)
+	require.NoError(err)
+
+	client := invitepb.NewInviteClient(cc)
+	resp, err := client.GetInviteCount(context.Background(), &invitepb.GetInviteCountRequest{
+		UserId: userID,
+	})
+	require.NoError(err)
+
+	result := Result(resp.InviteCount)
+	require.False(result.Mismatch())
+	require.Equal(ownerIndex, result.GetServerIndex())
+	require.Equal(userID.Value, result.GetUserID())
+}
+
+func TestCacheInvalidation(t *testing.T) {
+	require := require.New(t)
+
+	cluster := memory.NewCluster()
+	registry := registry.NewClusteredRegistry(cluster)
+
+	// Deployments using the gRPC cluster should install these globally.
+	cgrpc.RegisterResolver(registry)
+	cgrpc.RegisterLoadBalancer(registry)
+
+	servers, cleanup := setupServers(require, registry, 2, func() invitepb.InviteClient { return nil })
+	defer cleanup()
+
+	cc, err := grpc.Dial(
+		"cluster://authority/endpoint",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(cgrpc.BalancerConfig),
+	)
+	require.NoError(err)
+
+	client := invitepb.NewInviteClient(cc)
+	userID := &commonpb.UserId{Value: []byte{30}}
+
+	ctx := cgrpc.WithRoutingKey(context.Background(), userID.Value)
+
+	resp, err := client.GetInviteCount(ctx, &invitepb.GetInviteCountRequest{UserId: userID})
+	require.NoError(err)
+	resp, err = client.GetInviteCount(ctx, &invitepb.GetInviteCountRequest{UserId: userID})
+	require.NoError(err)
+
+	result := Result(resp.InviteCount)
+	require.True(result.Cached())
+
+	server := servers[result.GetServerIndex()]
+	server.service.cacheMu.Lock()
+	_, cached := server.service.cache[string(userID.Value)]
+	server.service.cacheMu.Unlock()
+	require.True(cached)
+
+	require.NoError(servers[result.GetServerIndex()].node.Deregister(ctx))
+	require.Eventually(func() bool {
+		_, cached = servers[result.GetServerIndex()].service.cache[string(userID.Value)]
+		return cached
+	}, 5*time.Second, 10*time.Millisecond)
+}

--- a/pkg/cluster/grpc/picker.go
+++ b/pkg/cluster/grpc/picker.go
@@ -1,0 +1,81 @@
+package grpc
+
+import (
+	"math/rand"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/code-payments/code-server/pkg/cluster/registry"
+	"github.com/code-payments/code-server/pkg/cluster/ring"
+)
+
+type picker struct {
+	nodes     []*registry.NodeDescriptor
+	subConns  map[string]balancer.SubConn
+	tokenRing *ring.HashRing
+}
+
+func newPicker(
+	nodes []*registry.NodeDescriptor,
+	subConns map[balancer.SubConn]*registry.NodeDescriptor,
+	tokenRing *ring.HashRing,
+) *picker {
+	p := &picker{
+		nodes:     nodes,
+		subConns:  make(map[string]balancer.SubConn),
+		tokenRing: tokenRing,
+	}
+
+	for sc, n := range subConns {
+		p.subConns[n.ID] = sc
+	}
+
+	return p
+}
+
+func (p *picker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+	var selectedNodeID string
+	if routingKey, ok := RoutingKey(info.Ctx); ok {
+		selectedNodeID = p.tokenRing.GetNode(routingKey)
+	} else {
+		selectedNodeID = p.getSimpleNode()
+	}
+
+	if selectedNodeID == "" {
+		return balancer.PickResult{}, status.Error(codes.Unavailable, "no endpoint available")
+	}
+
+	sc, ok := p.subConns[selectedNodeID]
+	if !ok {
+		return balancer.PickResult{}, balancer.ErrNoSubConnAvailable
+	}
+
+	return balancer.PickResult{SubConn: sc}, nil
+}
+
+func (p *picker) getSimpleNode() string {
+	if len(p.nodes) == 0 {
+		return ""
+	}
+
+	totalWeight := uint32(0)
+	for _, n := range p.nodes {
+		totalWeight += n.Weight
+	}
+	if totalWeight == 0 {
+		return ""
+	}
+
+	accumWeight := uint32(0)
+	targetWeight := uint32(rand.Int31n(int32(totalWeight)))
+	for _, n := range p.nodes {
+		accumWeight += n.Weight
+		if targetWeight < accumWeight {
+			return n.ID
+		}
+	}
+
+	return ""
+}

--- a/pkg/cluster/grpc/resolver.go
+++ b/pkg/cluster/grpc/resolver.go
@@ -1,0 +1,115 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"go.uber.org/zap"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/attributes"
+	"google.golang.org/grpc/resolver"
+
+	"github.com/code-payments/code-server/pkg/cluster/registry"
+	"github.com/code-payments/code-server/pkg/cluster/ring"
+)
+
+const (
+	Scheme = "cluster"
+
+	ringAttributeKey = "cluster-ring"
+)
+
+func RegisterResolver(registry registry.Observer) {
+	resolver.Register(&resolverBuilder{
+		log:      logrus.WithField("type", "cluster/grpc/registry"),
+		registry: registry,
+	})
+}
+
+type resolverBuilder struct {
+	log      *logrus.Entry
+	registry registry.Observer
+}
+
+func (rb *resolverBuilder) Scheme() string {
+	return Scheme
+}
+
+func (rb *resolverBuilder) Build(_ resolver.Target, cc resolver.ClientConn, _ resolver.BuildOptions) (resolver.Resolver, error) {
+	r := &registryResolver{
+		log:        logrus.StandardLogger().WithField("type", "cluster/grpc/registry"),
+		shutdownCh: make(chan struct{}),
+		cc:         cc,
+		obs:        rb.registry,
+	}
+
+	go r.watchEndpoints()
+
+	return r, nil
+}
+
+type registryResolver struct {
+	log *logrus.Entry
+	obs registry.Observer
+	cc  resolver.ClientConn
+
+	shutdownCh chan struct{}
+}
+
+func (r *registryResolver) ResolveNow(_ resolver.ResolveNowOptions) {
+	nodes, err := r.obs.GetNodes()
+	if err != nil {
+		r.log.WithError(err).Error("Failed to retrieve nodes")
+		if err = r.cc.UpdateState(resolver.State{Addresses: nil}); err != nil {
+			r.log.Error("Failed to clear local state", zap.Error(err))
+		}
+
+		return
+	}
+
+	r.resolveNodes(nodes)
+}
+
+func (r *registryResolver) Close() {
+	close(r.shutdownCh)
+}
+
+func (r *registryResolver) watchEndpoints() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-r.shutdownCh
+		cancel()
+	}()
+
+	for nodes := range r.obs.WatchNodes(ctx) {
+		r.resolveNodes(nodes)
+	}
+}
+
+func (r *registryResolver) resolveNodes(nodes []*registry.NodeDescriptor) {
+	claims := map[string]int{}
+	addresses := make([]resolver.Address, 0, len(nodes))
+	for _, n := range nodes {
+		n := n
+
+		if n.Address.IP == "" || n.Address.Port == 0 {
+			r.log.WithField("id", n.ID).Warn("Dropping node with missing address")
+			continue
+		}
+
+		claims[n.ID] = int(n.Weight)
+		addresses = append(addresses, resolver.Address{
+			Addr:       fmt.Sprintf("%s:%d", n.Address.IP, n.Address.Port),
+			Attributes: attributes.New(contextKeyNode, n),
+		})
+	}
+
+	r.log.Debug("Emitting addresses", zap.Int("addresses", len(addresses)))
+	err := r.cc.UpdateState(resolver.State{
+		Addresses:  addresses,
+		Attributes: attributes.New(ringAttributeKey, ring.NewRingFromMap(claims)),
+	})
+	if err != nil {
+		r.log.Error("Failed to update resolver", zap.Error(err))
+	}
+}

--- a/pkg/cluster/memory/memory_test.go
+++ b/pkg/cluster/memory/memory_test.go
@@ -1,13 +1,20 @@
 package memory
 
 import (
+	"net/http"
 	"testing"
+
+	_ "net/http/pprof"
 
 	"github.com/code-payments/code-server/pkg/cluster"
 	clustertests "github.com/code-payments/code-server/pkg/cluster/tests"
 )
 
 func TestMemory(t *testing.T) {
+	go func() {
+		http.ListenAndServe(":6060", nil)
+	}()
+
 	clustertests.RunClusterTests(t, func() (cluster.Cluster, error) {
 		return NewCluster(), nil
 	})

--- a/pkg/cluster/registry/cluster.go
+++ b/pkg/cluster/registry/cluster.go
@@ -1,0 +1,184 @@
+package registry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/code-payments/code-server/pkg/cluster"
+	"github.com/code-payments/code-server/pkg/cluster/ring"
+)
+
+type ClusterMember struct {
+	desc NodeDescriptor
+	m    cluster.Membership
+}
+
+func (c *ClusterMember) ID() string {
+	return c.m.ID()
+}
+
+func (c *ClusterMember) Register(ctx context.Context) error {
+	return c.m.Register(ctx)
+}
+
+func (c *ClusterMember) Deregister(ctx context.Context) error {
+	return c.m.Deregister(ctx)
+}
+
+func (c *ClusterMember) SetWeight(weight uint32) error {
+	c.desc.Weight = weight
+	b, err := json.Marshal(c.desc)
+	if err != nil {
+		return err
+	}
+
+	return c.m.SetData(string(b))
+}
+
+func (c *ClusterMember) GetWeight() uint32 {
+	return c.desc.Weight
+}
+
+type ClusteredRegistry struct {
+	log     *logrus.Entry
+	cluster cluster.Cluster
+
+	closeFn sync.Once
+	closeCh chan struct{}
+
+	nodesMu   sync.RWMutex
+	nodes     []*NodeDescriptor
+	tokenRing *ring.HashRing
+}
+
+func NewClusteredRegistry(cluster cluster.Cluster) *ClusteredRegistry {
+	c := &ClusteredRegistry{
+		log:       logrus.StandardLogger().WithField("type", "cluster/registry/ClusteredRegistry"),
+		cluster:   cluster,
+		closeCh:   make(chan struct{}),
+		tokenRing: ring.NewHashRing(),
+	}
+
+	go c.watch()
+
+	return c
+}
+
+func (c *ClusteredRegistry) Close() {
+	c.closeFn.Do(func() {
+		close(c.closeCh)
+	})
+}
+
+func (c *ClusteredRegistry) GetNode(id string) (*NodeDescriptor, error) {
+	c.nodesMu.RLock()
+	defer c.nodesMu.RUnlock()
+
+	for _, n := range c.nodes {
+		if n.ID == id {
+			return n, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *ClusteredRegistry) GetNodes() ([]*NodeDescriptor, error) {
+	c.nodesMu.RLock()
+	defer c.nodesMu.RUnlock()
+
+	return c.nodes, nil
+}
+
+func (c *ClusteredRegistry) Owner(token []byte) string {
+	return c.tokenRing.GetNode(token)
+}
+
+func (c *ClusteredRegistry) NewNode(addr string) (Node, error) {
+	parts := strings.Split(addr, ":")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid addr: %s", addr)
+	}
+
+	port, err := strconv.ParseUint(parts[1], 10, 16)
+	if err != nil {
+		return nil, fmt.Errorf("invalid port %q: %w", parts[1], err)
+	}
+
+	clusterMember, err := c.cluster.CreateMembership()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cluster member: %w", err)
+	}
+
+	member := &ClusterMember{
+		desc: NodeDescriptor{
+			ID: clusterMember.ID(),
+			Address: NodeAddress{
+				IP:   parts[0],
+				Port: int(port),
+			},
+			Weight: 0,
+		},
+		m: clusterMember,
+	}
+
+	return member, nil
+}
+
+func (c *ClusteredRegistry) WatchNodes(ctx context.Context) <-chan []*NodeDescriptor {
+	ch := make(chan []*NodeDescriptor, 1)
+
+	go func() {
+		for members := range c.cluster.WatchMembers(ctx) {
+			nodes := make([]*NodeDescriptor, 0, len(members))
+			for _, m := range members {
+				nd := &NodeDescriptor{}
+				if err := json.Unmarshal([]byte(m.Data), &nd); err != nil {
+					c.log.
+						WithError(err).
+						WithField("id", m.ID).
+						Warn("Failed to unmarshal node; dropping")
+
+					continue
+				}
+
+				nd.ID = m.ID
+				nodes = append(nodes, nd)
+			}
+
+			ch <- nodes
+		}
+	}()
+
+	return ch
+}
+
+func (c *ClusteredRegistry) watch() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-c.closeCh
+		cancel()
+	}()
+
+	for nodes := range c.WatchNodes(ctx) {
+		totalClaims := 0
+		claims := make(map[string]int, len(nodes))
+		for _, n := range nodes {
+			claims[n.ID] = int(n.Weight)
+			totalClaims += int(n.Weight)
+		}
+
+		tokenRing := ring.NewRingFromMap(claims)
+
+		c.nodesMu.Lock()
+		c.nodes = nodes
+		c.tokenRing = tokenRing
+		c.nodesMu.Unlock()
+	}
+}

--- a/pkg/cluster/registry/registry.go
+++ b/pkg/cluster/registry/registry.go
@@ -1,0 +1,69 @@
+package registry
+
+import (
+	"context"
+	"errors"
+)
+
+var (
+	ErrNodeNotFound = errors.New("endpoint not found")
+)
+
+type NodeDescriptor struct {
+	ID      string      `json:"id"`
+	Address NodeAddress `json:"address"`
+	Weight  uint32      `json:"weight,omitempty"`
+}
+
+type NodeAddress struct {
+	IP   string `json:"ip"`
+	Port int    `json:"port"`
+}
+
+type Node interface {
+	// ID returns the Nodes ID.
+	ID() string
+
+	// Register registers the endpoint with zero weighting.
+	//
+	// The endpoint should be visible to other processes after registering.
+	Register(ctx context.Context) error
+
+	// Deregister removes the endpoint from the registry.
+	//
+	// The endpoint should not be visible to other processes after de-registering.
+	Deregister(ctx context.Context) error
+
+	// SetWeight sets the weight (without delay) of the endpoint.
+	SetWeight(weight uint32) error
+
+	// GetWeight returns the current weight of the endpoint.
+	GetWeight() uint32
+}
+
+type Observer interface {
+	Reader
+	Watcher
+}
+
+type Reader interface {
+	// GetNode returns the node descriptor corresponding to the id.
+	//
+	// If there is no endpoint registered with the provided ID, ErrNodeNotFound is returned.
+	GetNode(id string) (*NodeDescriptor, error)
+
+	// GetNodes returns the set of services that are currently registered.
+	GetNodes() ([]*NodeDescriptor, error)
+
+	// Owner returns the Node.ID of the node that owns the specified token.
+	//
+	// If no owner exists, an empty string is returned.
+	Owner(token []byte) string
+}
+
+type Watcher interface {
+	// WatchNodes returns a channel that emits the entire set of nodes when
+	// a change occurs. The channel is closed when the observer is closed,
+	// or when the provided context is cancelled.
+	WatchNodes(ctx context.Context) <-chan []*NodeDescriptor
+}

--- a/pkg/cluster/tests/cluster_tests.go
+++ b/pkg/cluster/tests/cluster_tests.go
@@ -3,13 +3,11 @@ package tests
 import (
 	"context"
 	"fmt"
+	"github.com/code-payments/code-server/pkg/cluster"
 	"github.com/stretchr/testify/require"
 	"slices"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/code-payments/code-server/pkg/cluster"
 )
 
 func RunClusterTests(t *testing.T, ctor func() (cluster.Cluster, error)) {
@@ -19,7 +17,6 @@ func RunClusterTests(t *testing.T, ctor func() (cluster.Cluster, error)) {
 	}{
 		{name: "TestHappyPath", tf: testHappyPath},
 		{name: "TestWatchers", tf: testWatchers},
-		{name: "TestBlockedWatcher", tf: testBlockedWatcher},
 	} {
 		cluster, err := ctor()
 		require.NoError(t, err)
@@ -35,9 +32,10 @@ func testHappyPath(t *testing.T, c cluster.Cluster) {
 	watchCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	watch := c.WatchMembers(watchCtx)
+	w := c.WatchMembers(watchCtx)
+
 	awaitMembers := func() []cluster.Member {
-		watchMembers := <-watch
+		watchMembers := <-w
 		getMembers, err := c.GetMembers(ctx)
 		require.NoError(err)
 
@@ -66,7 +64,7 @@ func testHappyPath(t *testing.T, c cluster.Cluster) {
 	require.Equal(expectedMembers, awaitMembers())
 
 	for i, m := range memberships {
-		m.SetData(fmt.Sprintf("node-%d", i))
+		require.NoError(m.SetData(fmt.Sprintf("node-%d", i)))
 		expectedMembers = append(expectedMembers, cluster.Member{
 			ID:   m.ID(),
 			Data: m.Data(),
@@ -81,7 +79,7 @@ func testHappyPath(t *testing.T, c cluster.Cluster) {
 	// Step 3: Modify the data
 	//
 	for i, m := range memberships {
-		m.SetData(fmt.Sprintf("node-%d", 10+i))
+		require.NoError(m.SetData(fmt.Sprintf("node-%d", 10+i)))
 		expectedMembers[i].Data = m.Data()
 		require.Equal(expectedMembers, awaitMembers())
 	}
@@ -120,6 +118,21 @@ func testWatchers(t *testing.T, c cluster.Cluster) {
 		require.Empty(<-watches[i].ch)
 	}
 
+	waitClosed := func(ids []int) {
+		for {
+			closed := 0
+			for _, id := range ids {
+				if _, ok := <-watches[id].ch; !ok {
+					closed++
+				}
+			}
+			if closed == len(ids) {
+				return
+			}
+
+		}
+	}
+
 	member, err := c.CreateMembership()
 	require.NoError(err)
 	require.NoError(member.Register(ctx))
@@ -134,7 +147,8 @@ func testWatchers(t *testing.T, c cluster.Cluster) {
 		}
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	waitClosed([]int{0, 2, 4})
+
 	require.NoError(member.SetData("my data"))
 
 	for i := range watches {
@@ -148,70 +162,10 @@ func testWatchers(t *testing.T, c cluster.Cluster) {
 
 	c.Close()
 
-	time.Sleep(100 * time.Millisecond)
-
 	require.NoError(member.SetData("my data"))
 
 	for i := range watches {
 		_, ok := <-watches[i].ch
-		require.False(ok)
-	}
-}
-
-func testBlockedWatcher(t *testing.T, c cluster.Cluster) {
-	ctx := context.Background()
-	require := require.New(t)
-
-	watches := make([]watch, 5)
-	for i := range watches {
-		watchCtx, cancel := context.WithCancel(ctx)
-		watches[i] = watch{
-			ctx:    watchCtx,
-			cancel: cancel,
-			ch:     c.WatchMembers(watchCtx),
-		}
-		require.Empty(<-watches[i].ch)
-	}
-
-	mem, err := c.CreateMembership()
-	require.NoError(err)
-	require.NoError(mem.SetData("0"))
-	require.NoError(mem.Register(context.Background()))
-
-	//
-	// Phase 1: Only receive on even watchers (blocking on others)
-	//
-	expected := []cluster.Member{{ID: mem.ID(), Data: mem.Data()}}
-	for i := 0; i < 5; i++ {
-		for w := range watches {
-			if w%2 == 0 {
-				require.Equal(expected, <-watches[w].ch)
-			}
-		}
-
-		require.NoError(mem.SetData(fmt.Sprintf("%d", i+1)))
-		expected = []cluster.Member{{ID: mem.ID(), Data: mem.Data()}}
-	}
-
-	//
-	// Phase 2: At the end, the odd watchers should have buffered, while the rest is up-to-date.
-	//
-	delayed := []cluster.Member{{ID: mem.ID(), Data: "0"}}
-	for i, w := range watches {
-		if i%2 == 0 {
-			require.Equal(expected, <-w.ch)
-		} else {
-			require.Equal(delayed, <-w.ch)
-		}
-	}
-
-	//
-	// Phase 3: All watchers should be up-to-date after.
-	//          Critically, we're testing that there are dropped events.
-	//
-	require.NoError(mem.SetData("6"))
-	expected = []cluster.Member{{ID: mem.ID(), Data: mem.Data()}}
-	for _, w := range watches {
-		require.Equal(expected, <-w.ch)
+		require.False(ok, watches[i].ch)
 	}
 }

--- a/pkg/etcd/persistent_lease.go
+++ b/pkg/etcd/persistent_lease.go
@@ -73,6 +73,11 @@ func NewPersistentLease(client *v3.Client, key, val string, ttl time.Duration) (
 	return pl, nil
 }
 
+// Key returns the key of the persistent lease.
+func (pl *PersistentLease) Key() string {
+	return pl.key
+}
+
 // SetValue sets the new value for the persistent lease.
 //
 // SetValue is done concurrently, so there are no guarantees for when this will propagate.

--- a/pkg/etcd/wait.go
+++ b/pkg/etcd/wait.go
@@ -1,0 +1,41 @@
+package etcd
+
+import (
+	"context"
+
+	v3 "go.etcd.io/etcd/client/v3"
+)
+
+func WaitFor(ctx context.Context, client *v3.Client, key string, exists bool) error {
+	get, err := client.Get(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	if len(get.Kvs) == 0 && !exists {
+		return nil
+	} else if len(get.Kvs) > 0 && exists {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	watch := client.Watch(ctx, key, v3.WithRev(get.Header.Revision+1))
+	for w := range watch {
+		if err = w.Err(); err != nil {
+			return err
+		}
+
+		for _, e := range w.Events {
+			if e.Type == v3.EventTypePut && exists {
+				return nil
+			}
+			if e.Type == v3.EventTypeDelete && !exists {
+				return nil
+			}
+		}
+	}
+
+	return ctx.Err()
+}

--- a/pkg/etcd/wait_test.go
+++ b/pkg/etcd/wait_test.go
@@ -1,0 +1,92 @@
+package etcd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/code-payments/code-server/pkg/etcdtest"
+)
+
+func TestWaitCreate(t *testing.T) {
+	require := require.New(t)
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(err)
+
+	client, teardown, err := etcdtest.StartEtcd(pool)
+	require.NoError(err)
+	defer teardown()
+
+	resultCh := make(chan error)
+	go func() {
+		resultCh <- WaitFor(context.Background(), client, "/wait", true)
+	}()
+
+	select {
+	case <-resultCh:
+		require.Fail("should not have yielded")
+	case <-time.After(time.Second):
+	}
+
+	_, err = client.Put(context.Background(), "/wait", "1")
+	require.NoError(err)
+	require.NoError(<-resultCh)
+
+	require.NoError(WaitFor(context.Background(), client, "/wait", true))
+}
+
+func TestWaitDelete(t *testing.T) {
+	require := require.New(t)
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(err)
+
+	client, teardown, err := etcdtest.StartEtcd(pool)
+	require.NoError(err)
+	defer teardown()
+
+	require.NoError(WaitFor(context.Background(), client, "/wait", false))
+
+	_, err = client.Put(context.Background(), "/wait", "1")
+	require.NoError(err)
+
+	resultCh := make(chan error)
+	go func() {
+		resultCh <- WaitFor(context.Background(), client, "/wait", false)
+	}()
+
+	select {
+	case <-resultCh:
+		require.Fail("should not have yielded")
+	case <-time.After(time.Second):
+	}
+
+	_, err = client.Delete(context.Background(), "/wait")
+	require.NoError(err)
+	require.NoError(<-resultCh)
+}
+
+func TestWaitTimeout(t *testing.T) {
+	require := require.New(t)
+
+	pool, err := dockertest.NewPool("")
+	require.NoError(err)
+
+	client, teardown, err := etcdtest.StartEtcd(pool)
+	require.NoError(err)
+	defer teardown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err = WaitFor(ctx, client, "/wait", true)
+	elapsed := time.Since(start)
+
+	require.ErrorIs(err, context.DeadlineExceeded)
+	require.GreaterOrEqual(elapsed, time.Second)
+}


### PR DESCRIPTION
Adds infrastructure for 'smart clients' that can route requests based on
a context key either consistently or round robin, along with server side
hooks for validation/invalidation.

An end to end example exists under the example/ directory, which can be
used as a jumping off point for integration for other services.

This setup currently requires the use of explicit forwarding clients,
but server interceptors/gateways can be built using this infrastructure.
To do so would just be writing an interceptor/forwarder that uses a
ClientConnInterface using the balancer config.