### PR TITLE
chats: add (temporary) plumbing for tip notifications.

### DIFF
--- a/pkg/code/async/geyser/messenger.go
+++ b/pkg/code/async/geyser/messenger.go
@@ -165,7 +165,7 @@ func processPotentialBlockchainMessage(ctx context.Context, data code_data.Provi
 				return errors.Wrap(err, "error creating proto message")
 			}
 
-			canPush, err := chat_util.SendChatMessage(
+			canPush, err := chat_util.SendNotificationChatMessageV1(
 				ctx,
 				data,
 				asciiBaseDomain,

--- a/pkg/code/chat/message_cash_transactions.go
+++ b/pkg/code/chat/message_cash_transactions.go
@@ -148,7 +148,7 @@ func SendCashTransactionsExchangeMessage(ctx context.Context, data code_data.Pro
 			return errors.Wrap(err, "error creating proto chat message")
 		}
 
-		_, err = SendChatMessage(
+		_, err = SendNotificationChatMessageV1(
 			ctx,
 			data,
 			CashTransactionsName,

--- a/pkg/code/chat/message_code_team.go
+++ b/pkg/code/chat/message_code_team.go
@@ -16,7 +16,7 @@ import (
 
 // SendCodeTeamMessage sends a message to the Code Team chat.
 func SendCodeTeamMessage(ctx context.Context, data code_data.Provider, receiver *common.Account, chatMessage *chatpb.ChatMessage) (bool, error) {
-	return SendChatMessage(
+	return SendNotificationChatMessageV1(
 		ctx,
 		data,
 		CodeTeamName,

--- a/pkg/code/chat/message_kin_purchases.go
+++ b/pkg/code/chat/message_kin_purchases.go
@@ -23,7 +23,7 @@ func GetKinPurchasesChatId(owner *common.Account) chat_v1.ChatId {
 
 // SendKinPurchasesMessage sends a message to the Kin Purchases chat.
 func SendKinPurchasesMessage(ctx context.Context, data code_data.Provider, receiver *common.Account, chatMessage *chatpb.ChatMessage) (bool, error) {
-	return SendChatMessage(
+	return SendNotificationChatMessageV1(
 		ctx,
 		data,
 		KinPurchasesName,

--- a/pkg/code/chat/message_merchant.go
+++ b/pkg/code/chat/message_merchant.go
@@ -161,7 +161,7 @@ func SendMerchantExchangeMessage(ctx context.Context, data code_data.Provider, i
 			return nil, errors.Wrap(err, "error creating proto chat message")
 		}
 
-		canPush, err := SendChatMessage(
+		canPush, err := SendNotificationChatMessageV1(
 			ctx,
 			data,
 			chatTitle,

--- a/pkg/code/chat/message_tips.go
+++ b/pkg/code/chat/message_tips.go
@@ -2,15 +2,23 @@ package chat
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/mr-tron/base58"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	chatpb "github.com/code-payments/code-protobuf-api/generated/go/chat/v1"
+	chatv2pb "github.com/code-payments/code-protobuf-api/generated/go/chat/v2"
+	commonpb "github.com/code-payments/code-protobuf-api/generated/go/common/v1"
 
 	"github.com/code-payments/code-server/pkg/code/common"
 	code_data "github.com/code-payments/code-server/pkg/code/data"
 	chat_v1 "github.com/code-payments/code-server/pkg/code/data/chat/v1"
+	chat_v2 "github.com/code-payments/code-server/pkg/code/data/chat/v2"
 	"github.com/code-payments/code-server/pkg/code/data/intent"
+	chat_server "github.com/code-payments/code-server/pkg/code/server/grpc/chat/v2"
 )
 
 // SendTipsExchangeMessage sends a message to the Tips chat with exchange data
@@ -18,7 +26,12 @@ import (
 // Tips chat will be ignored.
 //
 // Note: Tests covered in SubmitIntent history tests
-func SendTipsExchangeMessage(ctx context.Context, data code_data.Provider, intentRecord *intent.Record) ([]*MessageWithOwner, error) {
+func SendTipsExchangeMessage(ctx context.Context, data code_data.Provider, notifier chat_server.Notifier, intentRecord *intent.Record) ([]*MessageWithOwner, error) {
+	intentIdRaw, err := base58.Decode(intentRecord.IntentId)
+	if err != nil {
+		return nil, fmt.Errorf("invalid intent id: %w", err)
+	}
+
 	messageId := intentRecord.IntentId
 
 	exchangeData, ok := getExchangeDataFromIntent(intentRecord)
@@ -30,7 +43,6 @@ func SendTipsExchangeMessage(ctx context.Context, data code_data.Provider, inten
 	switch intentRecord.IntentType {
 	case intent.SendPrivatePayment:
 		if !intentRecord.SendPrivatePaymentMetadata.IsTip {
-			// Not a tip
 			return nil, nil
 		}
 
@@ -61,30 +73,68 @@ func SendTipsExchangeMessage(ctx context.Context, data code_data.Provider, inten
 				},
 			},
 		}
-		protoMessage, err := newProtoChatMessage(messageId, content, intentRecord.CreatedAt)
+
+		v1Message, err := newProtoChatMessage(messageId, content, intentRecord.CreatedAt)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating proto chat message")
 		}
 
-		canPush, err := SendChatMessage(
+		v2Message := &chatv2pb.ChatMessage{
+			MessageId: chat_v2.GenerateMessageId().ToProto(),
+			Content: []*chatv2pb.Content{
+				{
+					Type: &chatv2pb.Content_ExchangeData{
+						ExchangeData: &chatv2pb.ExchangeDataContent{
+							Verb: chatv2pb.ExchangeDataContent_Verb(verb),
+							ExchangeData: &chatv2pb.ExchangeDataContent_Exact{
+								Exact: exchangeData,
+							},
+							Reference: &chatv2pb.ExchangeDataContent_Intent{
+								Intent: &commonpb.IntentId{Value: intentIdRaw},
+							},
+						},
+					},
+				},
+			},
+			Ts: timestamppb.New(intentRecord.CreatedAt),
+		}
+
+		canPush, err := SendNotificationChatMessageV1(
 			ctx,
 			data,
 			TipsName,
 			chat_v1.ChatTypeInternal,
 			true,
 			receiver,
-			protoMessage,
+			v1Message,
 			verb != chatpb.ExchangeDataContent_RECEIVED_TIP,
 		)
-		if err != nil && err != chat_v1.ErrMessageAlreadyExists {
-			return nil, errors.Wrap(err, "error persisting chat message")
+		if err != nil && !errors.Is(err, chat_v1.ErrMessageAlreadyExists) {
+			return nil, errors.Wrap(err, "error persisting v1 chat message")
+		}
+
+		_, err = SendNotificationChatMessageV2(
+			ctx,
+			data,
+			notifier,
+			TipsName,
+			true,
+			receiver,
+			v2Message,
+			intentRecord.IntentId,
+			verb != chatpb.ExchangeDataContent_RECEIVED_TIP,
+		)
+		if err != nil {
+			// TODO: Eventually we'll want to return an error, but for now we'll log
+			//       since we're not in 'prod' yet.
+			logrus.StandardLogger().WithError(err).Warn("Failed to send notification message (v2)")
 		}
 
 		if canPush {
 			messagesToPush = append(messagesToPush, &MessageWithOwner{
 				Owner:   receiver,
 				Title:   TipsName,
-				Message: protoMessage,
+				Message: v1Message,
 			})
 		}
 	}

--- a/pkg/code/chat/sender.go
+++ b/pkg/code/chat/sender.go
@@ -2,25 +2,30 @@ package chat
 
 import (
 	"context"
+	"database/sql"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/mr-tron/base58"
 	"google.golang.org/protobuf/proto"
 
 	chatpb "github.com/code-payments/code-protobuf-api/generated/go/chat/v1"
+	chatv2pb "github.com/code-payments/code-protobuf-api/generated/go/chat/v2"
 
 	"github.com/code-payments/code-server/pkg/code/common"
 	code_data "github.com/code-payments/code-server/pkg/code/data"
 	chat_v1 "github.com/code-payments/code-server/pkg/code/data/chat/v1"
+	chat_v2 "github.com/code-payments/code-server/pkg/code/data/chat/v2"
+	chatserver "github.com/code-payments/code-server/pkg/code/server/grpc/chat/v2"
 )
 
-// SendChatMessage sends a chat message to a receiving owner account.
+// SendNotificationChatMessageV1 sends a chat message to a receiving owner account.
 //
 // Note: This function is not responsible for push notifications. This method
 // might be called within the context of a DB transaction, which might have
-// unrelated failures. A hint as to whether a push should be sent is provided.
-func SendChatMessage(
+// unrelated failures. A hint whether a push should be sent is provided.
+func SendNotificationChatMessageV1(
 	ctx context.Context,
 	data code_data.Provider,
 	chatTitle string,
@@ -80,7 +85,7 @@ func SendChatMessage(
 		}
 
 		err = data.PutChatV1(ctx, chatRecord)
-		if err != nil && err != chat_v1.ErrChatAlreadyExists {
+		if err != nil && !errors.Is(err, chat_v1.ErrChatAlreadyExists) {
 			return false, err
 		}
 	default:
@@ -113,5 +118,133 @@ func SendChatMessage(
 		}
 	}
 
+	return canPushMessage, nil
+}
+
+func SendNotificationChatMessageV2(
+	ctx context.Context,
+	data code_data.Provider,
+	notifier chatserver.Notifier,
+	chatTitle string,
+	isVerifiedChat bool,
+	receiver *common.Account,
+	protoMessage *chatv2pb.ChatMessage,
+	intentId string,
+	isSilentMessage bool,
+) (canPushMessage bool, err error) {
+	chatId := chat_v2.GetChatId(chatTitle, receiver.PublicKey().ToBase58(), isVerifiedChat)
+
+	if protoMessage.Cursor != nil {
+		// Let the utilities and GetMessages RPC handle cursors
+		return false, errors.New("cursor must not be set")
+	}
+
+	if err := protoMessage.Validate(); err != nil {
+		return false, err
+	}
+
+	messageId, err := chat_v2.GetMessageIdFromProto(protoMessage.MessageId)
+	if err != nil {
+		return false, fmt.Errorf("invalid message id: %w", err)
+	}
+
+	// Clear out extracted metadata as a space optimization
+	cloned := proto.Clone(protoMessage).(*chatv2pb.ChatMessage)
+	cloned.MessageId = nil
+	cloned.Ts = nil
+	cloned.Cursor = nil
+
+	marshalled, err := proto.Marshal(cloned)
+	if err != nil {
+		return false, err
+	}
+
+	canPersistMessage := true
+	canPushMessage = !isSilentMessage
+
+	//
+	// Step 1: Check to see if we need to create the chat.
+	//
+	_, err = data.GetChatByIdV2(ctx, chatId)
+	if errors.Is(err, chat_v2.ErrChatNotFound) {
+		chatRecord := &chat_v2.ChatRecord{
+			ChatId:     chatId,
+			ChatType:   chat_v2.ChatTypeNotification,
+			ChatTitle:  &chatTitle,
+			IsVerified: isVerifiedChat,
+
+			CreatedAt: time.Now(),
+		}
+
+		err = data.ExecuteInTx(ctx, sql.LevelDefault, func(ctx context.Context) error {
+			err = data.PutChatV2(ctx, chatRecord)
+			if err != nil && !errors.Is(err, chat_v2.ErrChatExists) {
+				return fmt.Errorf("failed to initialize chat: %w", err)
+			}
+
+			err = data.PutChatMemberV2(ctx, &chat_v2.MemberRecord{
+				ChatId:     chatId,
+				MemberId:   chat_v2.GenerateMemberId(),
+				Platform:   chat_v2.PlatformCode,
+				PlatformId: receiver.PublicKey().ToBase58(),
+				JoinedAt:   time.Now(),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to initialize chat with member: %w", err)
+			}
+
+			return nil
+		})
+		if err != nil {
+			return false, err
+		}
+	} else if err != nil {
+		return false, err
+	}
+
+	//
+	// Step 2: Ensure that there is exactly 1 member in the chat.
+	//
+	members, err := data.GetAllChatMembersV2(ctx, chatId)
+	if errors.Is(err, chat_v2.ErrMemberNotFound) { // TODO: This is a weird error...
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	if len(members) > 1 {
+		// TODO: This _could_ get weird if client or someone else decides to join as another member.
+		return false, errors.New("notification chat should have at most 1 member")
+	}
+
+	canPersistMessage = !members[0].IsUnsubscribed
+	canPushMessage = canPushMessage && canPersistMessage && !members[0].IsMuted
+
+	if canPersistMessage {
+		refType := chat_v2.ReferenceTypeIntent
+		messageRecord := &chat_v2.MessageRecord{
+			ChatId:    chatId,
+			MessageId: messageId,
+
+			Data:     marshalled,
+			IsSilent: isSilentMessage,
+
+			ReferenceType: &refType,
+			Reference:     &intentId,
+		}
+
+		// TODO: Once we have a better idea on the data modeling around chatv2,
+		//       we may wish to have the server manage the creation of messages
+		//       (and chats?) as well. That would also put the
+		err = data.PutChatMessageV2(ctx, messageRecord)
+		if err != nil {
+			return false, err
+		}
+
+		notifier.NotifyMessage(ctx, chatId, protoMessage)
+	}
+
+	// TODO: Once we move more things over to chatv2, we will need to increment
+	//       badge count here. We don't currently, as it would result in a double
+	//       push.
 	return canPushMessage, nil
 }

--- a/pkg/code/chat/sender_test.go
+++ b/pkg/code/chat/sender_test.go
@@ -33,9 +33,8 @@ func TestSendChatMessage_HappyPath(t *testing.T) {
 		chatMessage := newRandomChatMessage(t, i+1)
 		expectedBadgeCount += 1
 
-		canPush, err := SendChatMessage(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, false)
+		canPush, err := SendNotificationChatMessageV1(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, false)
 		require.NoError(t, err)
-
 		assert.True(t, canPush)
 
 		assert.NotNil(t, chatMessage.MessageId)
@@ -56,7 +55,7 @@ func TestSendChatMessage_VerifiedChat(t *testing.T) {
 
 	for _, isVerified := range []bool{true, false} {
 		chatMessage := newRandomChatMessage(t, 1)
-		_, err := SendChatMessage(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, isVerified, receiver, chatMessage, true)
+		_, err := SendNotificationChatMessageV1(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, isVerified, receiver, chatMessage, true)
 		require.NoError(t, err)
 		env.assertChatRecordSaved(t, chatTitle, receiver, isVerified)
 	}
@@ -71,7 +70,7 @@ func TestSendChatMessage_SilentMessage(t *testing.T) {
 
 	for i, isSilent := range []bool{true, false} {
 		chatMessage := newRandomChatMessage(t, 1)
-		canPush, err := SendChatMessage(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, isSilent)
+		canPush, err := SendNotificationChatMessageV1(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, isSilent)
 		require.NoError(t, err)
 		assert.Equal(t, !isSilent, canPush)
 		env.assertChatMessageRecordSaved(t, chatId, chatMessage, isSilent)
@@ -92,7 +91,7 @@ func TestSendChatMessage_MuteState(t *testing.T) {
 		}
 
 		chatMessage := newRandomChatMessage(t, 1)
-		canPush, err := SendChatMessage(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, false)
+		canPush, err := SendNotificationChatMessageV1(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, false)
 		require.NoError(t, err)
 		assert.Equal(t, !isMuted, canPush)
 		env.assertChatMessageRecordSaved(t, chatId, chatMessage, false)
@@ -113,7 +112,7 @@ func TestSendChatMessage_SubscriptionState(t *testing.T) {
 		}
 
 		chatMessage := newRandomChatMessage(t, 1)
-		canPush, err := SendChatMessage(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, false)
+		canPush, err := SendNotificationChatMessageV1(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, false)
 		require.NoError(t, err)
 		assert.Equal(t, !isUnsubscribed, canPush)
 		if isUnsubscribed {
@@ -135,7 +134,7 @@ func TestSendChatMessage_InvalidProtoMessage(t *testing.T) {
 	chatMessage := newRandomChatMessage(t, 1)
 	chatMessage.Content = nil
 
-	canPush, err := SendChatMessage(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, false)
+	canPush, err := SendNotificationChatMessageV1(env.ctx, env.data, chatTitle, chat_v1.ChatTypeInternal, true, receiver, chatMessage, false)
 	assert.Error(t, err)
 	assert.False(t, canPush)
 	env.assertChatRecordNotSaved(t, chatId)

--- a/pkg/code/data/chat/v2/id.go
+++ b/pkg/code/data/chat/v2/id.go
@@ -2,7 +2,10 @@ package chat_v2
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -27,6 +30,14 @@ func GetChatIdFromBytes(buffer []byte) (ChatId, error) {
 	}
 
 	return typed, nil
+}
+
+func GetChatId(sender, receiver string, isVerified bool) ChatId {
+	combined := []byte(fmt.Sprintf("%s:%s:%v", sender, receiver, isVerified))
+	if strings.Compare(sender, receiver) > 0 {
+		combined = []byte(fmt.Sprintf("%s:%s:%v", receiver, sender, isVerified))
+	}
+	return sha256.Sum256(combined)
 }
 
 // GetChatIdFromBytes gets a chat ID from the string representation

--- a/pkg/code/server/grpc/chat/v1/server_test.go
+++ b/pkg/code/server/grpc/chat/v1/server_test.go
@@ -894,12 +894,12 @@ func setup(t *testing.T) (env *testEnv, cleanup func()) {
 }
 
 func (e *testEnv) sendExternalAppChatMessage(t *testing.T, msg *chatpb.ChatMessage, domain string, isVerified bool, recipient *common.Account) {
-	_, err := chat_util.SendChatMessage(e.ctx, e.data, domain, chat.ChatTypeExternalApp, isVerified, recipient, msg, false)
+	_, err := chat_util.SendNotificationChatMessageV1(e.ctx, e.data, domain, chat.ChatTypeExternalApp, isVerified, recipient, msg, false)
 	require.NoError(t, err)
 }
 
 func (e *testEnv) sendInternalChatMessage(t *testing.T, msg *chatpb.ChatMessage, chatTitle string, recipient *common.Account) {
-	_, err := chat_util.SendChatMessage(e.ctx, e.data, chatTitle, chat.ChatTypeInternal, true, recipient, msg, false)
+	_, err := chat_util.SendNotificationChatMessageV1(e.ctx, e.data, chatTitle, chat.ChatTypeInternal, true, recipient, msg, false)
 	require.NoError(t, err)
 }
 

--- a/pkg/code/server/grpc/chat/v2/notifier.go
+++ b/pkg/code/server/grpc/chat/v2/notifier.go
@@ -1,0 +1,22 @@
+package chat_v2
+
+import (
+	"context"
+
+	chatpb "github.com/code-payments/code-protobuf-api/generated/go/chat/v2"
+
+	chat "github.com/code-payments/code-server/pkg/code/data/chat/v2"
+)
+
+type Notifier interface {
+	NotifyMessage(ctx context.Context, chatID chat.ChatId, message *chatpb.ChatMessage)
+}
+
+type NoopNotifier struct{}
+
+func NewNoopNotifier() *NoopNotifier {
+	return &NoopNotifier{}
+}
+
+func (n *NoopNotifier) NotifyMessage(_ context.Context, _ chat.ChatId, _ *chatpb.ChatMessage) {
+}

--- a/pkg/code/server/grpc/transaction/v2/history_test.go
+++ b/pkg/code/server/grpc/transaction/v2/history_test.go
@@ -3,6 +3,7 @@ package transaction_v2
 import (
 	"testing"
 
+	"github.com/mr-tron/base58"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -13,6 +14,7 @@ import (
 	chat_util "github.com/code-payments/code-server/pkg/code/chat"
 	"github.com/code-payments/code-server/pkg/code/common"
 	chat_v1 "github.com/code-payments/code-server/pkg/code/data/chat/v1"
+	chat_v2 "github.com/code-payments/code-server/pkg/code/data/chat/v2"
 	currency_lib "github.com/code-payments/code-server/pkg/currency"
 	"github.com/code-payments/code-server/pkg/kin"
 	timelock_token_v1 "github.com/code-payments/code-server/pkg/solana/timelock/v1"
@@ -338,6 +340,10 @@ func TestPaymentHistory_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, chatMessageRecords, 1)
 
+	chatMessageRecordsV2, err := server.data.GetAllChatMessagesV2(server.ctx, chat_v2.GetChatId(chat_util.TipsName, sendingPhone.parentAccount.PublicKey().ToBase58(), true))
+	require.NoError(t, err)
+	requireEquivalent(t, chatMessageRecords, chatMessageRecordsV2)
+
 	protoChatMessage = getProtoChatMessage(t, chatMessageRecords[0])
 	require.Len(t, protoChatMessage.Content, 1)
 	require.NotNil(t, protoChatMessage.Content[0].GetExchangeData())
@@ -413,6 +419,10 @@ func TestPaymentHistory_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, chatMessageRecords, 1)
 
+	chatMessageRecordsV2, err = server.data.GetAllChatMessagesV2(server.ctx, chat_v2.GetChatId(chat_util.TipsName, receivingPhone.parentAccount.PublicKey().ToBase58(), true))
+	require.NoError(t, err)
+	requireEquivalent(t, chatMessageRecords, chatMessageRecordsV2)
+
 	protoChatMessage = getProtoChatMessage(t, chatMessageRecords[0])
 	require.Len(t, protoChatMessage.Content, 1)
 	require.NotNil(t, protoChatMessage.Content[0].GetExchangeData())
@@ -421,4 +431,50 @@ func TestPaymentHistory_HappyPath(t *testing.T) {
 	assert.Equal(t, 0.1, protoChatMessage.Content[0].GetExchangeData().GetExact().ExchangeRate)
 	assert.Equal(t, 45.6, protoChatMessage.Content[0].GetExchangeData().GetExact().NativeAmount)
 	assert.Equal(t, kin.ToQuarks(456), protoChatMessage.Content[0].GetExchangeData().GetExact().Quarks)
+}
+
+func requireEquivalent(t *testing.T, v1 []*chat_v1.Message, v2 []*chat_v2.MessageRecord) {
+	require.Equal(t, len(v1), len(v2))
+
+	for i, v1Record := range v1 {
+		v2Record := v2[i]
+
+		require.Equal(t, v1Record.ChatId[:], v2Record.ChatId[:])
+		require.Equal(t, v1Record.IsSilent, v2Record.IsSilent)
+
+		v1Message := getProtoChatMessage(t, v1Record)
+		require.Empty(t, v1Message.Sender)
+
+		v2Message := getProtoChatMessageV2(t, v2Record)
+		require.Empty(t, v2Message.SenderId)
+
+		require.Equal(t, len(v1Message.Content), len(v2Message.Content))
+
+		// TODO: Move this to somewhere common?
+		for c := range v1Message.Content {
+			a := v1Message.Content[c].GetExchangeData()
+			require.NotNil(t, a)
+
+			b := v2Message.Content[c].GetExchangeData()
+			require.NotNil(t, b)
+
+			require.EqualValues(t, a.Verb, b.Verb)
+
+			if a.GetExact() != nil {
+				require.Equal(t, a.GetExact().Currency, b.GetExact().Currency)
+				require.Equal(t, a.GetExact().ExchangeRate, b.GetExact().ExchangeRate)
+				require.Equal(t, a.GetExact().NativeAmount, b.GetExact().NativeAmount)
+				require.Equal(t, a.GetExact().Quarks, b.GetExact().Quarks)
+			} else if a.GetPartial() != nil {
+				require.Equal(t, a.GetPartial().Currency, b.GetPartial().Currency)
+				require.Equal(t, a.GetPartial().NativeAmount, b.GetPartial().NativeAmount)
+			} else {
+				t.Fatal("Unhandled case")
+			}
+
+			intent := b.GetIntent()
+			require.NotNil(t, intent)
+			require.Equal(t, v1Record.MessageId, base58.Encode(intent.Value))
+		}
+	}
 }

--- a/pkg/code/server/grpc/transaction/v2/intent.go
+++ b/pkg/code/server/grpc/transaction/v2/intent.go
@@ -888,7 +888,7 @@ func (s *transactionServer) SubmitIntent(streamer transactionpb.Transaction_Subm
 				return err
 			}
 
-			tipMessagesToPush, err := chat_util.SendTipsExchangeMessage(ctx, s.data, intentRecord)
+			tipMessagesToPush, err := chat_util.SendTipsExchangeMessage(ctx, s.data, s.notifier, intentRecord)
 			if err != nil {
 				log.WithError(err).Warn("failure updating tips chat")
 				return err

--- a/pkg/code/server/grpc/transaction/v2/server.go
+++ b/pkg/code/server/grpc/transaction/v2/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/code-payments/code-server/pkg/code/common"
 	code_data "github.com/code-payments/code-server/pkg/code/data"
 	"github.com/code-payments/code-server/pkg/code/lawenforcement"
+	chat_server "github.com/code-payments/code-server/pkg/code/server/grpc/chat/v2"
 	"github.com/code-payments/code-server/pkg/code/server/grpc/messaging"
 	"github.com/code-payments/code-server/pkg/jupiter"
 	"github.com/code-payments/code-server/pkg/kin"
@@ -29,7 +30,8 @@ type transactionServer struct {
 
 	auth *auth_util.RPCSignatureVerifier
 
-	pusher push_lib.Provider
+	pusher   push_lib.Provider
+	notifier chat_server.Notifier
 
 	jupiterClient *jupiter.Client
 
@@ -65,6 +67,7 @@ type transactionServer struct {
 func NewTransactionServer(
 	data code_data.Provider,
 	pusher push_lib.Provider,
+	notifier chat_server.Notifier,
 	jupiterClient *jupiter.Client,
 	messagingClient messaging.InternalMessageClient,
 	maxmind *maxminddb.Reader,
@@ -85,7 +88,8 @@ func NewTransactionServer(
 
 		auth: auth_util.NewRPCSignatureVerifier(data),
 
-		pusher: pusher,
+		pusher:   pusher,
+		notifier: notifier,
 
 		jupiterClient: jupiterClient,
 

--- a/pkg/code/server/grpc/transaction/v2/testutil.go
+++ b/pkg/code/server/grpc/transaction/v2/testutil.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	chatpb "github.com/code-payments/code-protobuf-api/generated/go/chat/v1"
+	chatv2pb "github.com/code-payments/code-protobuf-api/generated/go/chat/v2"
 	commonpb "github.com/code-payments/code-protobuf-api/generated/go/common/v1"
 	messagingpb "github.com/code-payments/code-protobuf-api/generated/go/messaging/v1"
 	transactionpb "github.com/code-payments/code-protobuf-api/generated/go/transaction/v2"
@@ -36,6 +37,7 @@ import (
 	"github.com/code-payments/code-server/pkg/code/data/account"
 	"github.com/code-payments/code-server/pkg/code/data/action"
 	chat_v1 "github.com/code-payments/code-server/pkg/code/data/chat/v1"
+	chat_v2 "github.com/code-payments/code-server/pkg/code/data/chat/v2"
 	"github.com/code-payments/code-server/pkg/code/data/commitment"
 	"github.com/code-payments/code-server/pkg/code/data/currency"
 	"github.com/code-payments/code-server/pkg/code/data/deposit"
@@ -55,6 +57,7 @@ import (
 	user_identity "github.com/code-payments/code-server/pkg/code/data/user/identity"
 	"github.com/code-payments/code-server/pkg/code/data/vault"
 	exchange_rate_util "github.com/code-payments/code-server/pkg/code/exchangerate"
+	chat_server "github.com/code-payments/code-server/pkg/code/server/grpc/chat/v2"
 	"github.com/code-payments/code-server/pkg/code/server/grpc/messaging"
 	transaction_util "github.com/code-payments/code-server/pkg/code/transaction"
 	currency_lib "github.com/code-payments/code-server/pkg/currency"
@@ -184,6 +187,7 @@ func setupTestEnv(t *testing.T, serverOverrides *testOverrides) (serverTestEnv, 
 	testService := NewTransactionServer(
 		db,
 		memory_push.NewPushProvider(),
+		chat_server.NewNoopNotifier(),
 		nil,
 		messaging.NewMessagingClient(db),
 		nil,
@@ -6177,4 +6181,10 @@ func getProtoChatMessage(t *testing.T, record *chat_v1.Message) *chatpb.ChatMess
 	var protoMessage chatpb.ChatMessage
 	require.NoError(t, proto.Unmarshal(record.Data, &protoMessage))
 	return &protoMessage
+}
+
+func getProtoChatMessageV2(t *testing.T, record *chat_v2.MessageRecord) *chatv2pb.ChatMessage {
+	protoMessage := &chatv2pb.ChatMessage{}
+	require.NoError(t, proto.Unmarshal(record.Data, protoMessage))
+	return protoMessage
 }


### PR DESCRIPTION
Adds enough plumbing for the tip notifications to flow through v2 (without breaking the previous system, hopefully). When the protocol is more flushed out, and the base messaging infra is shored up a bit, this will likely be revisted